### PR TITLE
Look for configuration in $XDG_CONFIG_HOME/mblaze

### DIFF
--- a/README
+++ b/README
@@ -87,10 +87,12 @@ EXAMPLES
      As usual with pipes, the sky is the limit.
 
 CONCEPTS
-     mblaze deals with messages (which are files), folders (which are Maildir
-     folders), sequences (which are newline-separated lists of messages,
-     possibly persisted on disk in ~/.mblaze/seq), and the current message
-     (kept as a symlink in ~/.mblaze/cur).
+     mblaze deals with messages (which are files), folders (which are
+     Maildir folders), sequences (which are newline-separated lists of
+     messages, possibly persisted on disk in <mblaze_dir>/seq), and the
+     current message (kept as a symlink in <mbalze_dir>mblaze/cur),
+     where <mblaze_dir> is $XDG_CONFIG_HOME/mblaze if that directory
+     exists, or $HOME/.mblaze if not.
 
      Messages in the persisted sequence can be referred to using special
      syntax as explained in mmsg(7).

--- a/contrib/mpeek
+++ b/contrib/mpeek
@@ -1,7 +1,15 @@
 #!/bin/sh
 # mpeek - wrapper around mscan with a different seq
 
-export MAILSEQ=$HOME/.mblaze/peek.seq
+if [ -z "$XDG_CONFIG_HOME" ]; then
+	MAILSEQ="$XDG_CONFIG_HOME/mblaze"
+else
+	MAILSEQ="$HOME/.config/mblaze"
+fi
+
+[ ! -d "$MAILSEQ" ] && MAILSEQ="$HOME/.mblaze"
+
+export MAILSEQ=$MAILSEQ/peek.seq
 
 if [ -t 0 ]; then
 	mseq "$@"

--- a/man/mblaze.7
+++ b/man/mblaze.7
@@ -144,9 +144,9 @@ As usual with pipes, the sky is the limit.
 deals with messages (which are files),
 folders (which are Maildir folders),
 sequences (which are newline-separated lists of messages, possibly persisted on disk in
-.Pa ~/.mblaze/seq ) ,
+.Pa $XDG_CONFIG_HOME/mblaze/seq ) ,
 and the current message (kept as a symlink in
-.Pa ~/.mblaze/cur ) .
+.Pa $XDG_CONFIG_HOME/mblaze/cur ) .
 .Pp
 Messages in the persisted sequence can be referred to using special
 syntax as explained in

--- a/man/mcom.1
+++ b/man/mcom.1
@@ -52,7 +52,7 @@ Editor used to compose mail.
 .Bl -tag -width Ds
 .It Pa snd.*
 Draft messages (kept in current directory)
-.It Pa ~/.mblaze/headers
+.It Pa $XDG_CONFIG_HOME/mblaze/headers
 Default headers for each mail.
 (Put your
 .Sq Li From\&:

--- a/man/mgenmid.1
+++ b/man/mgenmid.1
@@ -19,7 +19,7 @@ The fully qualified domain name is computed by:
 Using
 .Sq Li "FQDN:"
 from
-.Pa "~/.mblaze/profile"
+.Pa "$XDG_CONFIG_HOME/mblaze/profile"
 (if set).
 .It
 Resolving the current hostname.
@@ -27,7 +27,7 @@ Resolving the current hostname.
 Using the host part of the address in
 .Sq Li "Local-Mailbox:"
 from
-.Pa "~/.mblaze/profile"
+.Pa "$XDG_CONFIG_HOME/mblaze/profile"
 (if set).
 .El
 .Pp

--- a/man/mseq.1
+++ b/man/mseq.1
@@ -71,7 +71,7 @@ and exit.
 .It Ev MAILCUR
 Symbolic link referring to the current message.
 (Default:
-.Pa ~/.mblaze/cur )
+.Pa $XDG_CONFIG_HOME/mblaze/cur )
 .It Ev MAILDOT
 When set to a file name, overrides the current message.
 (Prefer using
@@ -80,7 +80,7 @@ instead.)
 .It Ev MAILSEQ
 File were the sequence is stored.
 (Default:
-.Pa ~/.mblaze/seq )
+.Pa $XDG_CONFIG_HOME/mblaze/seq )
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/man/mshow.1
+++ b/man/mshow.1
@@ -99,7 +99,7 @@ parts,
 and re-encodes them into UTF-8 if necessary.
 .Pp
 Other filters can be specified in the file
-.Pa ~/.mblaze/filter
+.Pa $XDG_CONFIG_HOME/mblaze/filter
 in the format
 .D1 Ar type/subtype Ns Li \&: Ar command
 or

--- a/mcom
+++ b/mcom
@@ -18,7 +18,15 @@ msgdate() {
 	mdate
 }
 
-outbox=$(mhdr -h outbox ~/.mblaze/profile)
+if [ -z "$XDG_CONFIG_HOME" ]; then
+	mblaze_home = "$HOME/.config/mblaze"
+else
+	mblaze_home = "$XDG_CONFIG_HOME/mblaze"
+fi
+
+[ -d "$mblaze_home" ] || mblaze_home = "$HOME/.mblaze"
+
+outbox=$(mhdr -h outbox "$mblaze_home/profile")
 if [ -z "$outbox" ]; then
 	i=0
 	while [ -f "snd.$i" ]; do
@@ -43,9 +51,9 @@ fi
 		echo "Cc: "
 		echo "Bcc: "
 		echo "Subject: "
-		from=$(mhdr -h local-mailbox ~/.mblaze/profile)
+		from=$(mhdr -h local-mailbox $mblaze_home/profile)
 		[ "$from" ] && echo "From: $from"
-		cat ~/.mblaze/headers 2>/dev/null
+		cat "$mblaze_home/headers" 2>/dev/null
 		msgid
 		msgdate
 		echo
@@ -59,7 +67,7 @@ fi
 		echo "Cc: $(mhdr -d -A -h to:cc: "$1" | commajoin)"
 		echo "Bcc: "
 		echo "Subject: Re: $(mscan -f '%S' "$1")"
-		cat ~/.mblaze/headers 2>/dev/null
+		cat "$mblaze_home/headers" 2>/dev/null
 		mid=$(mhdr -h message-id "$1")
 		if [ "$mid" ]; then
 			echo -n "References:"

--- a/mgenmid.c
+++ b/mgenmid.c
@@ -31,7 +31,7 @@ int main()
 	char hostbuf[1024];
 	char *host = 0;
 
-	char *f = blaze822_home_file(".mblaze/profile");
+	char *f = blaze822_home_file("profile");
 	struct message *config = blaze822(f);
 
 	if (config) // try FQDN: first
@@ -74,7 +74,7 @@ int main()
 	if (!host) {
 		fprintf(stderr,
 		    "mgenmid: failed to find a FQDN for the Message-ID.\n"
-		    " Define 'FQDN:' or 'Local-Mailbox:' in ~/.mblaze/profile\n"
+		    " Define 'FQDN:' or 'Local-Mailbox:' in $XDG_CONFIG_HOME/mblaze/profile\n"
 		    " or add a FQDN to /etc/hosts.\n");
 		exit(1);
 	}

--- a/mless
+++ b/mless
@@ -62,10 +62,19 @@ fi
 
 nl="
 "
+
+if [ -z "$XDG_CONFIG_HOME" ]; then
+	LESSKEY = "$HOME/.config/mblaze/mless"
+else
+	LESSKEY = "$XDG_CONFIG_HOME/mblaze/mless"
+fi
+
+[ -f "$LESSKEY" ] || LESSKEY = "$HOME/.mless"
+[ -f "$LESSKEY" ] && export LESSKEY
+
 export MLESS_RAW=0
 export MLESS_HTML=0
 while :; do
-	[ -f $HOME/.mless ] && export LESSKEY=$HOME/.mless
 	LESSOPEN="|$0 --filter %s" \
 		less -Ps"mless %f?m (message %i of %m).." -R \
 			"+:e $(mscan -n .)$nl" //scan $(mscan -n :)

--- a/mscan.c
+++ b/mscan.c
@@ -517,7 +517,7 @@ main(int argc, char *argv[])
 	if (cols <= 40)
 		cols = 80;
 
-	char *f = blaze822_home_file(".mblaze/profile");
+	char *f = blaze822_home_file("profile");
 	struct message *config = blaze822(f);
 
 	if (config) {

--- a/mseq.c
+++ b/mseq.c
@@ -186,7 +186,7 @@ stdinmode()
 		// XXX locking?
 		seqfile = getenv("MAILSEQ");
 		if (!seqfile)
-			seqfile = blaze822_home_file(".mblaze/seq");
+			seqfile = blaze822_home_file("seq");
 		snprintf(tmpfile, sizeof tmpfile, "%s-", seqfile);
 		snprintf(oldfile, sizeof oldfile, "%s.old", seqfile);
 		outfile = fopen(tmpfile, "w+");

--- a/mshow.c
+++ b/mshow.c
@@ -728,7 +728,7 @@ main(int argc, char *argv[])
 		if (!(qflag || rflag)) {
 			char *f = getenv("MAILFILTER");
 			if (!f)
-				f = blaze822_home_file(".mblaze/filter");
+				f = blaze822_home_file("filter");
 			if (f)
 				filters = blaze822(f);
 		}


### PR DESCRIPTION
Fall back to $HOME/.config/mblaze or $HOME/.mblaze, in that order. Existing users do not need to move their configurations.

As a side benefit, anything that calls blaze822_home_file only needs to worry about the filename, so the rest of the path only needs to be set in one place.