### PR TITLE
Add $MBLAZE environment variable to set profile location

### DIFF
--- a/README
+++ b/README
@@ -87,10 +87,11 @@ EXAMPLES
      As usual with pipes, the sky is the limit.
 
 CONCEPTS
-     mblaze deals with messages (which are files), folders (which are Maildir
-     folders), sequences (which are newline-separated lists of messages,
-     possibly persisted on disk in ~/.mblaze/seq), and the current message
-     (kept as a symlink in ~/.mblaze/cur).
+     mblaze deals with messages (which are files), folders (which are
+     Maildir folders), sequences (which are newline-separated lists of
+     messages, possibly persisted on disk in
+     ${MBLAZE:-$HOME/.mblaze}/seq), and the current message
+     (kept as a symlink in ${MBLAZE:-$HOME/.mblaze}/cur).
 
      Messages in the persisted sequence can be referred to using special
      syntax as explained in mmsg(7).

--- a/README
+++ b/README
@@ -87,11 +87,10 @@ EXAMPLES
      As usual with pipes, the sky is the limit.
 
 CONCEPTS
-     mblaze deals with messages (which are files), folders (which are
-     Maildir folders), sequences (which are newline-separated lists of
-     messages, possibly persisted on disk in
-     ${MBLAZE:-$HOME/.mblaze}/seq), and the current message
-     (kept as a symlink in ${MBLAZE:-$HOME/.mblaze}/cur).
+     mblaze deals with messages (which are files), folders (which are Maildir
+     folders), sequences (which are newline-separated lists of messages,
+     possibly persisted on disk in ~/.mblaze/seq), and the current message
+     (kept as a symlink in ~/.mblaze/cur).
 
      Messages in the persisted sequence can be referred to using special
      syntax as explained in mmsg(7).

--- a/contrib/mpeek
+++ b/contrib/mpeek
@@ -1,7 +1,7 @@
 #!/bin/sh
 # mpeek - wrapper around mscan with a different seq
 
-export MAILSEQ=$HOME/.mblaze/peek.seq
+export MAILSEQ=${MBLAZE:-$HOME/.mblaze}/peek.seq
 
 if [ -t 0 ]; then
 	mseq "$@"

--- a/man/mblaze.7
+++ b/man/mblaze.7
@@ -144,9 +144,9 @@ As usual with pipes, the sky is the limit.
 deals with messages (which are files),
 folders (which are Maildir folders),
 sequences (which are newline-separated lists of messages, possibly persisted on disk in
-.Pa ~/.mblaze/seq ) ,
+.Pa ${MBLAZE:-$HOME/.mblaze}/seq ) ,
 and the current message (kept as a symlink in
-.Pa ~/.mblaze/cur ) .
+.Pa ${MBLAZE:-$HOME/.mblaze}/cur ) .
 .Pp
 Messages in the persisted sequence can be referred to using special
 syntax as explained in

--- a/man/mcom.1
+++ b/man/mcom.1
@@ -47,17 +47,21 @@ Delete the draft and quit.
 .Bl -tag -width Ds
 .It Ev EDITOR
 Editor used to compose mail.
+.It Ev MBLAZE
+Directory containing mblaze configuration.
+(Default:
+.Pa $HOME/.mblaze)
 .El
 .Sh FILES
 .Bl -tag -width Ds
 .It Pa snd.*
 Draft messages (kept in current directory)
-.It Pa ~/.mblaze/headers
+.It Pa ${MBLAZE:-$HOME/.mblaze}/headers
 Default headers for each mail.
 (Put your
 .Sq Li From\&:
 line there.)
-.It Pa ~/.signature
+.It Pa ${MBLAZE:-$HOME/.mblaze}/signature || ~/.signature
 Default signature.
 .El
 .Sh EXIT STATUS

--- a/man/mcom.1
+++ b/man/mcom.1
@@ -50,7 +50,7 @@ Editor used to compose mail.
 .It Ev MBLAZE
 Directory containing mblaze configuration.
 (Default:
-.Pa $HOME/.mblaze)
+.Pa $HOME/.mblaze )
 .El
 .Sh FILES
 .Bl -tag -width Ds

--- a/man/mgenmid.1
+++ b/man/mgenmid.1
@@ -19,7 +19,7 @@ The fully qualified domain name is computed by:
 Using
 .Sq Li "FQDN:"
 from
-.Pa "~/.mblaze/profile"
+.Pa "${MBLAZE:-$HOME/.mblaze}/profile"
 (if set).
 .It
 Resolving the current hostname.
@@ -27,7 +27,7 @@ Resolving the current hostname.
 Using the host part of the address in
 .Sq Li "Local-Mailbox:"
 from
-.Pa "~/.mblaze/profile"
+.Pa "${MBLAZE:-$HOME/.mblaze}/profile"
 (if set).
 .El
 .Pp

--- a/man/mseq.1
+++ b/man/mseq.1
@@ -68,10 +68,14 @@ and exit.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
+.It Ev MBLAZE
+Directory containing mblaze configuration.
+(Default:
+.Pa $HOME/.mblaze)
 .It Ev MAILCUR
 Symbolic link referring to the current message.
 (Default:
-.Pa ~/.mblaze/cur )
+.Pa ${MBLAZE:-$HOME/.mblaze}/cur )
 .It Ev MAILDOT
 When set to a file name, overrides the current message.
 (Prefer using
@@ -80,7 +84,7 @@ instead.)
 .It Ev MAILSEQ
 File were the sequence is stored.
 (Default:
-.Pa ~/.mblaze/seq )
+.Pa ${MBLAZE:-$HOME/.mblaze}/seq )
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/man/mseq.1
+++ b/man/mseq.1
@@ -71,7 +71,7 @@ and exit.
 .It Ev MBLAZE
 Directory containing mblaze configuration.
 (Default:
-.Pa $HOME/.mblaze)
+.Pa $HOME/.mblaze )
 .It Ev MAILCUR
 Symbolic link referring to the current message.
 (Default:

--- a/man/mshow.1
+++ b/man/mshow.1
@@ -99,7 +99,7 @@ parts,
 and re-encodes them into UTF-8 if necessary.
 .Pp
 Other filters can be specified in the file
-.Pa ~/.mblaze/filter
+.Pa ${MBLAZE:-$HOME/.mblaze}/filter
 in the format
 .D1 Ar type/subtype Ns Li \&: Ar command
 or

--- a/mcom
+++ b/mcom
@@ -18,7 +18,8 @@ msgdate() {
 	mdate
 }
 
-outbox=$(mhdr -h outbox ~/.mblaze/profile)
+MBLAZE=${MBLAZE:-$HOME/.mblaze}
+outbox=$(mhdr -h outbox $MBLAZE/profile)
 if [ -z "$outbox" ]; then
 	i=0
 	while [ -f "snd.$i" ]; do
@@ -43,9 +44,9 @@ fi
 		echo "Cc: "
 		echo "Bcc: "
 		echo "Subject: "
-		from=$(mhdr -h local-mailbox ~/.mblaze/profile)
+		from=$(mhdr -h local-mailbox $MBLAZE/profile)
 		[ "$from" ] && echo "From: $from"
-		cat ~/.mblaze/headers 2>/dev/null
+		cat $MBLAZE/headers 2>/dev/null
 		msgid
 		msgdate
 		echo
@@ -59,7 +60,7 @@ fi
 		echo "Cc: $(mhdr -d -A -h to:cc: "$1" | commajoin)"
 		echo "Bcc: "
 		echo "Subject: Re: $(mscan -f '%S' "$1")"
-		cat ~/.mblaze/headers 2>/dev/null
+		cat $MBLAZE/headers 2>/dev/null
 		mid=$(mhdr -h message-id "$1")
 		if [ "$mid" ]; then
 			echo -n "References:"
@@ -77,9 +78,17 @@ fi
 		echo
 	esac
 
-	if [ -f ~/.signature ]; then
+	if [ -f $MBLAZE/signature ]; then
+		SIGNATURE=$MBLAZE/signature
+	elif [ -f $HOME/.mblaze/signature ]; then
+		SIGNATURE=$HOME/.mblaze/signature
+	elif [ -f ~/.signature ]; then
+		SIGNATURE=$HOME/.signature
+	fi
+
+	if [ ! -z $SIGNATURE ]; then
 		printf '%s\n' '-- '
-		cat ~/.signature
+		cat $SIGNATURE
 	fi
 } >$draft
 

--- a/mcom
+++ b/mcom
@@ -19,7 +19,7 @@ msgdate() {
 }
 
 MBLAZE=${MBLAZE:-$HOME/.mblaze}
-outbox=$(mhdr -h outbox $MBLAZE/profile)
+outbox=$(mhdr -h outbox "$MBLAZE/profile")
 if [ -z "$outbox" ]; then
 	i=0
 	while [ -f "snd.$i" ]; do
@@ -44,9 +44,9 @@ fi
 		echo "Cc: "
 		echo "Bcc: "
 		echo "Subject: "
-		from=$(mhdr -h local-mailbox $MBLAZE/profile)
+		from=$(mhdr -h local-mailbox "$MBLAZE/profile")
 		[ "$from" ] && echo "From: $from"
-		cat $MBLAZE/headers 2>/dev/null
+		cat "$MBLAZE/headers" 2>/dev/null
 		msgid
 		msgdate
 		echo
@@ -60,7 +60,7 @@ fi
 		echo "Cc: $(mhdr -d -A -h to:cc: "$1" | commajoin)"
 		echo "Bcc: "
 		echo "Subject: Re: $(mscan -f '%S' "$1")"
-		cat $MBLAZE/headers 2>/dev/null
+		cat "$MBLAZE/headers" 2>/dev/null
 		mid=$(mhdr -h message-id "$1")
 		if [ "$mid" ]; then
 			echo -n "References:"
@@ -78,17 +78,15 @@ fi
 		echo
 	esac
 
-	if [ -f $MBLAZE/signature ]; then
-		SIGNATURE=$MBLAZE/signature
-	elif [ -f $HOME/.mblaze/signature ]; then
-		SIGNATURE=$HOME/.mblaze/signature
+	if [ -f "$MBLAZE/signature" ]; then
+		SIGNATURE="$MBLAZE/signature"
 	elif [ -f ~/.signature ]; then
-		SIGNATURE=$HOME/.signature
+		SIGNATURE="$HOME/.signature"
 	fi
 
-	if [ ! -z $SIGNATURE ]; then
+	if [ -n "$SIGNATURE" ]; then
 		printf '%s\n' '-- '
-		cat $SIGNATURE
+		cat "$SIGNATURE"
 	fi
 } >$draft
 

--- a/mgenmid.c
+++ b/mgenmid.c
@@ -31,7 +31,7 @@ int main()
 	char hostbuf[1024];
 	char *host = 0;
 
-	char *f = blaze822_home_file(".mblaze/profile");
+	char *f = blaze822_home_file("profile");
 	struct message *config = blaze822(f);
 
 	if (config) // try FQDN: first
@@ -74,7 +74,8 @@ int main()
 	if (!host) {
 		fprintf(stderr,
 		    "mgenmid: failed to find a FQDN for the Message-ID.\n"
-		    " Define 'FQDN:' or 'Local-Mailbox:' in ~/.mblaze/profile\n"
+		    " Define 'FQDN:' or 'Local-Mailbox:' in"
+		    " ${MBLAZE:-$HOME/.mblaze}/profile\n"
 		    " or add a FQDN to /etc/hosts.\n");
 		exit(1);
 	}

--- a/mless
+++ b/mless
@@ -65,7 +65,13 @@ nl="
 export MLESS_RAW=0
 export MLESS_HTML=0
 while :; do
-	[ -f $HOME/.mless ] && export LESSKEY=$HOME/.mless
+	if [ -f $MBLAZE/mless ]; then
+		export LESSKEY=$MBLAZE/mless
+	elif [ -f $HOME/.mblaze/mless ]; then
+		export LESSKEY=$HOME/.mblaze/mless
+	elif [ -f $HOME/.mless ]; then
+		export LESSKEY=$HOME/.mless
+	fi
 	LESSOPEN="|$0 --filter %s" \
 		less -Ps"mless %f?m (message %i of %m).." -R \
 			"+:e $(mscan -n .)$nl" //scan $(mscan -n :)

--- a/mscan.c
+++ b/mscan.c
@@ -517,7 +517,7 @@ main(int argc, char *argv[])
 	if (cols <= 40)
 		cols = 80;
 
-	char *f = blaze822_home_file(".mblaze/profile");
+	char *f = blaze822_home_file("profile");
 	struct message *config = blaze822(f);
 
 	if (config) {

--- a/mseq.c
+++ b/mseq.c
@@ -186,7 +186,7 @@ stdinmode()
 		// XXX locking?
 		seqfile = getenv("MAILSEQ");
 		if (!seqfile)
-			seqfile = blaze822_home_file(".mblaze/seq");
+			seqfile = blaze822_home_file("seq");
 		snprintf(tmpfile, sizeof tmpfile, "%s-", seqfile);
 		snprintf(oldfile, sizeof oldfile, "%s.old", seqfile);
 		outfile = fopen(tmpfile, "w+");

--- a/mshow.c
+++ b/mshow.c
@@ -728,7 +728,7 @@ main(int argc, char *argv[])
 		if (!(qflag || rflag)) {
 			char *f = getenv("MAILFILTER");
 			if (!f)
-				f = blaze822_home_file(".mblaze/filter");
+				f = blaze822_home_file("filter");
 			if (f)
 				filters = blaze822(f);
 		}

--- a/seq.c
+++ b/seq.c
@@ -21,6 +21,14 @@ blaze822_home_file(char *basename)
 {
 	static char path[PATH_MAX];
 	static char *homedir;
+	static char *profile;
+
+	if (!profile)
+		profile = getenv("MBLAZE");
+	if (profile) {
+		snprintf(path, sizeof path, "%s/%s", profile, basename);
+		return path;
+	}
 
 	if (!homedir)
 		homedir = getenv("HOME");
@@ -34,7 +42,7 @@ blaze822_home_file(char *basename)
 	if (!homedir)
 		return "/dev/null/homeless";
 
-	snprintf(path, sizeof path, "%s/%s", homedir, basename);
+	snprintf(path, sizeof path, "%s/.mblaze/%s", homedir, basename);
 
 	return path;
 }
@@ -49,7 +57,7 @@ blaze822_seq_open(char *file)
 	if (!file)
 		file = getenv("MAILSEQ");
 	if (!file)
-		file = blaze822_home_file(".mblaze/seq");
+		file = blaze822_home_file("seq");
 	fd = open(file, O_RDONLY);
 	if (!fd)
 		return 0;
@@ -138,7 +146,7 @@ blaze822_seq_cur(void)
 
 	char *curlink = getenv("MAILCUR");
 	if (!curlink)
-		curlink = blaze822_home_file(".mblaze/cur");
+		curlink = blaze822_home_file("cur");
 
 	int r = readlink(curlink, b, sizeof b - 1);
 	if (r < 0)
@@ -157,7 +165,7 @@ blaze822_seq_setcur(char *s)
 	char curtmplink[PATH_MAX];
 	char *curlink = getenv("MAILCUR");
 	if (!curlink)
-		curlink = blaze822_home_file(".mblaze/cur");
+		curlink = blaze822_home_file("cur");
 
 	if (snprintf(curtmplink, sizeof curtmplink, "%s-", curlink) >= PATH_MAX)
 		return -1;  // truncation


### PR DESCRIPTION
As a side benefit, all callers of blaze822_home_file need only pass
the filename, so the base directory is set in only one place.