### PR TITLE
Makefile: Install .7 manuals to $MANDIR/man7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -O2 -Wall -Wno-switch -Wextra -fstack-protector-strong -D_FORTIFY_SOURCE=2
+CFLAGS+=-g -O2 -Wall -Wno-switch -Wextra -fstack-protector-strong -D_FORTIFY_SOURCE=2
 
 DESTDIR=
 PREFIX=/usr/local

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 CFLAGS+=-g -O2 -Wall -Wno-switch -Wextra -fstack-protector-strong -D_FORTIFY_SOURCE=2
 
-DESTDIR=
 PREFIX=/usr/local
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install: FRC all
 	install -m0755 $(ALL) $(SCRIPT) $(DESTDIR)$(BINDIR)
 	ln -sf mless $(DESTDIR)$(BINDIR)/mnext
 	ln -sf mless $(DESTDIR)$(BINDIR)/mprev
-	ln -sf mrep $(DESTDIR)$(BINDIR)/mcom
+	ln -sf mcom $(DESTDIR)$(BINDIR)/mrep
 	install -m0644 man/*.1 $(DESTDIR)$(MANDIR)/man1
 	install -Dm0644 man/*.7 $(DESTDIR)$(MANDIR)/man7
 

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,13 @@ clean: FRC
 	-rm -f $(ALL) *.o
 
 install: FRC all
-	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1
+	mkdir -p $(DESTDIR)$(BINDIR) $(DESTDIR)$(MANDIR)/man1 \
+		$(DESTDIR)$(MANDIR)/man7
 	install -m0755 $(ALL) $(SCRIPT) $(DESTDIR)$(BINDIR)
 	ln -sf mless $(DESTDIR)$(BINDIR)/mnext
 	ln -sf mless $(DESTDIR)$(BINDIR)/mprev
 	ln -sf mrep $(DESTDIR)$(BINDIR)/mcom
-	install -m0644 man/*.[0-9] $(DESTDIR)$(MANDIR)/man1
+	install -m0644 man/*.1 $(DESTDIR)$(MANDIR)/man1
+	install -Dm0644 man/*.7 $(DESTDIR)$(MANDIR)/man7
 
 FRC:


### PR DESCRIPTION
Title's the important one.

One just removes the line initializing an empty DESTDIR, and one changes the CFLAGS initialization to use += so any CFLAGS the user passes prepend to rather than replace the defaults. Enjoy!