### PR TITLE
Mcom: fix mime attach when outbox set, allow user to specify alt sendmail

### DIFF
--- a/mcom
+++ b/mcom
@@ -19,6 +19,11 @@ msgdate() {
 }
 
 MBLAZE=${MBLAZE:-$HOME/.mblaze}
+
+sendmail=$(mhdr -h sendmail "$MBLAZE/profile")
+sendmail_args=$(mhdr -h sendmail_args "$MBLAZE/profile")
+sendmail="${sendmail:-sendmail} ${sendmail_args:--t}"
+
 outbox=$(mhdr -h outbox "$MBLAZE/profile")
 if [ -z "$outbox" ]; then
 	i=0
@@ -96,7 +101,7 @@ while :; do
 	s|send)
 		if [ -e $draftmime ]; then
 			if [ $draft -ot $draftmime ]; then
-				if sendmail -t <$draftmime; then
+				if $sendmail -t <$draftmime; then
 					if [ "$outbox" ]; then
 						mv $draftmime $draft
 						mflag -d $draft
@@ -105,7 +110,7 @@ while :; do
 					fi
 					exit 0
 				else
-					echo "mcom: sendmail failed, kept draft $draft"
+					echo "mcom: $sendmail failed, kept draft $draft"
 					exit 2
 				fi
 			else
@@ -114,7 +119,7 @@ while :; do
 			fi
 		else
 			if mmime -c <$draft; then
-				if sendmail -t <$draft; then
+				if $sendmail -t <$draft; then
 					if [ "$outbox" ]; then
 						mflag -d $draft
 					else
@@ -122,7 +127,7 @@ while :; do
 					fi
 					exit 0
 				else
-					echo "mcom: sendmail failed, kept draft $draft"
+					echo "mcom: $sendmail failed, kept draft $draft"
 					exit 2
 				fi
 			else

--- a/mcom
+++ b/mcom
@@ -33,7 +33,7 @@ else
 		echo "$0: failed to create draft in outbox $outbox." 1>&2
 		exit 1
 	fi
-	draftmime="$(echo $draft | sed 's,\(.*\)/cur/,\1/tmp/mime-,')"
+	draftmime="$(echo $draft | sed 's,\(.*\)/new/,\1/tmp/mime-,')"
 fi
 
 {


### PR DESCRIPTION
A sed substitution that mcom ran when outbox was set wasn't updated to account for drafts being delivered to <maildir>/new, so the draft was being overwritten.

Patch 2: mcom now looks for sendmail and sendmail_args headers in $MBLAZE/profile. It still defaults to sendmail -t. Use case: msmtp is installed, but so is legacy sendmail.