### PR TITLE
mcom: don't make $draft look like a sequence

### DIFF
--- a/mcom
+++ b/mcom
@@ -30,7 +30,7 @@ if [ -z "$outbox" ]; then
 	while [ -f "snd.$i" ]; do
 		i=$((i+1))
 	done
-	draft="snd.$i"
+	draft="./snd.$i"
 	draftmime="./snd.$i.mime"
 else
 	draft="$(true | mdeliver -v -c -XD "$outbox")"


### PR DESCRIPTION
Make sure $draft look like a file by prefixing it with "./", to avoid errors when we call other programs like msed.