### PR TITLE
mgenmid: fix fallback random generation on 32bit

### DIFF
--- a/mgenmid.c
+++ b/mgenmid.c
@@ -99,7 +99,7 @@ int main()
 	} else {
 fallback:
 		srand48(tp.tv_sec ^ tp.tv_usec ^ getpid());
-		rnd = (lrand48() << 32) + lrand48();
+		rnd = ((uint64_t)lrand48() << 32) + lrand48();
 	}
 
 	rnd |= (1LL << 63);  // set highest bit to force full width


### PR DESCRIPTION
lrand48 returns a long int, which is 32bits wide on 32bits systems