### PR TITLE
correct typos and wording in documentation

### DIFF
--- a/man/mblaze-profile.5
+++ b/man/mblaze-profile.5
@@ -27,21 +27,21 @@ for comments:
 Please bear in mind that empty lines will stop parsing.
 .Pp
 The following
-.Ar key
+.Ar keys
 are used by
 .Xr mblaze 7 :
 .Bl -tag -width Ds
 .It Li "Alternate-Mailboxes:"
 A comma-separated list of mail addresses that belong to you, for
 .Xr mscan 1
-to recognize them as sent to you.
+to recognize messages sent by or directly to you.
 .It Li "FQDN:"
 The fully qualified domain name used for
 .Li "Message-Id:"
 generation in
 .Xr mgenmid 1 .
 .It Li "Local-Mailbox:"
-Your primary mail address, used as default value for
+Your primary mail address, used as the default value for
 .Li "From:"
 in
 .Xr mcom 1 ,

--- a/man/mblaze.7
+++ b/man/mblaze.7
@@ -86,14 +86,14 @@ or similar.
 expects your mail to reside in Maildir folders.
 .Pp
 .Nm
-operates directly on Maildir and doesn't use own caches or databases.
+operates directly on Maildir and doesn't use its own caches or databases.
 There is no setup needed for many uses.
 All tools have been written with performance in mind.
 Enumeration of all mails in a Maildir is avoided unless necessary,
-and then optimized to use few syscalls.
-Parsing mail metadata is optimized to use few I/O requests.
+and then optimized to limit syscalls.
+Parsing mail metadata is optimized to limit I/O requests.
 Initial operations on big Maildir may feel slow, but as soon as they
-are in file system cache, everything is blazing fast.
+are in the file system cache, everything is blazingly fast.
 The tools are written to be memory efficient (i.e. not wasteful), but
 whole messages are assumed to fit into RAM easily (one at a time).
 .Pp
@@ -119,7 +119,7 @@ or
 .Xr mu 1 .
 .Sh EXAMPLES
 .Nm
-tools are designed to be composed together into a pipe.
+tools are designed to be composed together in a pipe.
 It is suitable for interactive use and for scripting.
 It integrates well into a Unix workflow.
 .Pp
@@ -130,7 +130,7 @@ To operate on a set of mails in multiple steps, you can save a list of mail
 as a sequence.
 E.g. add a call to
 .Ql mseq -S
-to above command:
+to the above command:
 .Dl mlist -s ~/Maildir/INBOX | msort -d | mseq -S | mscan
 Now mscan will show message numbers and you could look at the first
 five mails at once, for example:
@@ -147,12 +147,12 @@ As usual with pipes, the sky is the limit.
 .Nm
 deals with messages (which are files),
 folders (which are Maildir folders),
-sequences (which are newline-separated lists of messages, possibly persisted on disk in
+sequences (which are newline-separated lists of messages, possibly saved on disk in
 .Pa ${MBLAZE:-$HOME/.mblaze}/seq ) ,
 and the current message (kept as a symlink in
 .Pa ${MBLAZE:-$HOME/.mblaze}/cur ) .
 .Pp
-Messages in the persisted sequence can be referred to using special
+Messages in the saved sequence can be referred to using special
 syntax as explained in
 .Xr mmsg 7 .
 .Pp

--- a/man/mcom.1
+++ b/man/mcom.1
@@ -23,13 +23,13 @@ After editing, a loop is started where the user can re-edit, send or
 cancel the mail.
 Use
 .Sq Nm Fl r
-to resume editing a draft.
+to resume the editing of a draft.
 By default, the last modified draft will be edited.
 .Pp
 .Nm mfwd
 behaves like
 .Nm mcom
-but fills the draft with subject and body to forward the messages.
+but fills the draft with a subject and body appropriate for forwarding the messages.
 By default, messages are forwarded verbatim as MIME
 .Sq Li message/rfc822
 attachments.

--- a/man/mflag.1
+++ b/man/mflag.1
@@ -16,7 +16,7 @@
 .Op Ar msgs\ ...
 .Sh DESCRIPTION
 .Nm
-flags changes the flags of the given
+changes the flags of the given
 .Ar msgs
 according to the options.
 See
@@ -52,7 +52,7 @@ as trashed.
 .It Fl X Ar str
 Mark
 .Ar msgs
-as with the chracters in
+with the characters in
 .Ar str .
 .It Fl d
 Unmark
@@ -81,14 +81,14 @@ as trashed.
 .It Fl x Ar str
 Unmark
 .Ar msgs
-as with the chracters in
+with the characters in
 .Ar str .
 (Remember to use uppercase characters.)
 .It Fl v
 Read Maildir mails from stdin (or the use the whole current sequence, if
 used interactively) and print the transformed list of file names.
 .Pp
-Can be used to keep the sequence intact in advent of renames.
+This can be used to keep the sequence intact in the case of renames.
 .El
 .Pp
 Note that the

--- a/man/mlist.1
+++ b/man/mlist.1
@@ -3,7 +3,7 @@
 .Os
 .Sh NAME
 .Nm mlist
-.Nd list mesages in Maildir folders
+.Nd list messages in Maildir folders
 .Sh SYNOPSIS
 .Nm
 .Op Fl DFPRST
@@ -40,7 +40,7 @@ Only list messages marked as seen.
 .It Fl T
 Only list messages marked as trashed.
 .It Fl X Ar str
-Only list messages marked with the chracters in
+Only list messages marked with the characters in
 .Ar str .
 .It Fl d
 Don't list messages marked as draft.
@@ -55,7 +55,7 @@ Don't list messages marked as seen.
 .It Fl t
 Don't list messages marked as trashed.
 .It Fl x Ar str
-Don't list messages marked with the chracters in
+Don't list messages marked with the characters in
 .Ar str .
 (Remember to use uppercase characters.)
 .It Fl C

--- a/man/mmime.1
+++ b/man/mmime.1
@@ -18,7 +18,7 @@ encodes the standard input into a MIME message.
 generates a
 .Sq Li multipart/mixed
 mail from standard input,
-extending, wrapping, and encoding the header as neccessary,
+extending, wrapping, and encoding the header as necessary,
 and replacing body lines looking like
 .Pp
 .D1 Li # Ns Ar content Ns Li / Ns Ar type Ns Oo Ns Li # Ns Ar content-disposition Oc Pa path Ns Oo Li > Ns Ar filename Oc

--- a/man/mpick.1
+++ b/man/mpick.1
@@ -93,7 +93,7 @@ tests are given by the following EBNF:
              | <timeprop> <numop> <dur>
              | <numprop> <numop> <num>
              | <strprop> <strop> <str>
-             | prune             -- do not match futher messages in thread
+             | prune             -- do not match further messages in thread
              | print             -- always true value
 
 <flagprop> ::= child | draft | flagged | info | new | parent | passed

--- a/man/msed.1
+++ b/man/msed.1
@@ -39,7 +39,7 @@ The mail body is copied as-is.
 supports the following commands.
 The separators
 .Em after
-the command letter may be subsituted with an arbitrary symbol, just as in
+the command letter may be substituted with an arbitrary symbol, just as in
 .Xr sed 1 .
 Multiple commands can be separated by
 .Sq Cm \&; .


### PR DESCRIPTION
While reading the documentation I made corrections to typos and spellings as I noticed them. There was also a few missing articles on nouns. Note that "persist" is an intransitive verb so "persisted" is not a word. A couple of the changes are fairly subtle but I'm happy to explain any in more detail if you want.