### PR TITLE
Fix for thread message syntax relative to . or $

### DIFF
--- a/seq.c
+++ b/seq.c
@@ -337,7 +337,8 @@ parse_parent(char *map, long *starto, long *stopo)
 static int
 parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 {
-	*start = *stop = 1;
+	*start = 0;
+	*stop = 1;
 
 	while (*a && *a != ':' && *a != '=' && *a != '_' && *a != '^') {
 		char *b = parse_relnum(a, cur, lines, start);
@@ -345,6 +346,8 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 			return 0;
 		a = b;
 	}
+	if (*start == 0)
+	    *start = strchr("=^_", *a) ? cur : 1;
 
 	while (*a == '^') {
 		a++;

--- a/seq.c
+++ b/seq.c
@@ -185,10 +185,11 @@ parse_relnum(char *a, long cur, long last, long *out)
 		a = ".-1";
 	else if (strcmp(a, ".") == 0)
 		a = ".+0";
-	else if (strcmp(a, "$") == 0)
-		a = "-1";
 
-	if (*a == '.') {
+	if (*a == '$') {
+		a++;
+		base = last;
+	} else if (*a == '.') {
 		a++;
 		base = cur;
 	} else if (*a == '-') {
@@ -198,7 +199,7 @@ parse_relnum(char *a, long cur, long last, long *out)
 	}
 
 	long d;
-	if (*a == ':') {
+	if (strchr(":=_^", *a)) {
 		d = 0;
 		b = a;
 	} else {

--- a/seq.c
+++ b/seq.c
@@ -174,7 +174,7 @@ blaze822_seq_setcur(char *s)
 }
 
 static char *
-parse_relnum(char *a, long cur, long last, long *out)
+parse_relnum(char *a, long cur, long start, long last, long *out)
 {
 	long base;
 	char *b;
@@ -194,6 +194,8 @@ parse_relnum(char *a, long cur, long last, long *out)
 		base = cur;
 	} else if (*a == '-') {
 		base = last + 1;
+	} else if (*a == '+') {
+		base = start;
 	} else {
 		base = 0;
 	}
@@ -341,7 +343,7 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 	*stop = 1;
 
 	while (*a && *a != ':' && *a != '=' && *a != '_' && *a != '^') {
-		char *b = parse_relnum(a, cur, lines, start);
+		char *b = parse_relnum(a, cur, 0, lines, start);
 		if (a == b)
 			return 0;
 		a = b;
@@ -360,7 +362,7 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 		if (!*a) {
 			*stop = lines;
 		} else {
-			char *b = parse_relnum(a, cur, lines, stop);
+			char *b = parse_relnum(a, cur, *start, lines, stop);
 			if (a == b)
 				return 0;
 		}


### PR DESCRIPTION
With a message such as .^ specified, strtol() was used on the caret. On Linux this works because strtol() doesn't return an error but it fails on, e.g. FreeBSD. Furthermore, it was not
possible to specify relative offsets after $, either stuff like $-4 or $^

I think there's still scope for some cleanup here. Let me know on these points because I may be motivated to do a patch.

* If a message isn't found for a valid parse, the error message could be better, e.g. "can't parse range: 4^"
* A number larger than the last message shows the last message. Should it be an error?
* Things like .4 works as a shortcut for .+4. Are you happy with that
* With multiple numbers, only the last is used: 100-2 is a shortcut for -2. Allowing 0-2 might be good to avoid needing, e.g mscan -- -2 100-2+4 could be useful to allow as a shortcut for 102: could be useful if the numbers get built up in a script.
* Plain =, ^ etc appear to be a shortcut for 1= 1^. Is that sensible? Error? Shortcut for .= ?
