### PR TITLE
Changes to mblaze-profile.5

### DIFF
--- a/man/mblaze-profile.5
+++ b/man/mblaze-profile.5
@@ -3,28 +3,29 @@
 .Os
 .Sh NAME
 .Nm mblaze-profile
-.Nd configuration and customization for mblaze message system
+.Nd configuration of the mblaze message system
 .Sh DESCRIPTION
 The
 .Xr mblaze 7
 message system can be configured with a
 .Pa profile
-configuration file,
-which usually resides in
+file,
+which is located in the directory
 .Pa ~/.mblaze
 (or
 .Ev MBLAZE
 if set.)
 .Pp
-This file consists of a RFC 2822 style header message with lines like
+.Pa profile
+consists of lines, similar to RFC 2822 headers, in the form
 .Dl Ar key Ns \&: Ar value
 .Pp
-You can use a key
+The key
 .Sq Cm \&#
-for comments:
+may be used to precede a comment:
 .Dl Li "#:" Ar comment
 .Pp
-Please bear in mind that empty lines will stop parsing.
+Please note that empty lines will halt parsing.
 .Pp
 The following
 .Ar key Ns s
@@ -51,28 +52,28 @@ to recognize messages sent to you.
 .It Li "Outbox:"
 If set,
 .Xr mcom 1
-will create the draft message in this Maildir,
-and not delete it after it has been sent.
+will create draft messages in this Maildir,
+and save messages there after sending.
 .It Li "Scan-Format:"
 The default format string for
 .Xr mscan 1 .
 .It Li "Sendmail:"
-The binary path used to send mail for
+The program that
 .Xr mcom 1
-(default:
+will call to send mail.
+(Default:
 .Sq Li sendmail ) .
 .It Li "Sendmail-Args:"
-The flags used to send mail with
+Flags to be passed to the
 .Li "Sendmail:"
-for
-.Xr mcom 1
-(default
+program.
+(Default:
 .Sq Fl t ) .
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width Ds
 .It Ev MBLAZE
-Directory containing mblaze configuration.
+Directory containing mblaze configuration files.
 (Default:
 .Pa $HOME/.mblaze )
 .El


### PR DESCRIPTION
- SYNOPSIS: Delete 'and customization', change 'for' to 'of'
- Tidy up first few lines of DESCRIPTION
- Change wording for 'Outbox:'
- Change wording for 'Sendmail: and 'Sendmail-Args:'
- Add 'files' to 'configuration' in ENVIRONMENT