### PR TITLE
Standardise on 'filename' (not 'file name') in manual pages

### DIFF
--- a/man/magrep.1
+++ b/man/magrep.1
@@ -79,7 +79,7 @@ or
 .Fl v
 is specified.
 .It Fl p
-Print the file name,
+Print the filename,
 the header and the matching line
 for each of the matched
 .Ar msgs .

--- a/man/mcom.1
+++ b/man/mcom.1
@@ -55,7 +55,7 @@ Send the mail.
 The MIME version will be used when one has been created.
 .It Ic c
 Cancel sending and quit after displaying
-the file name of the saved draft.
+the filename of the saved draft.
 .It Ic m
 Run
 .Xr mmime 1

--- a/man/mexport.1
+++ b/man/mexport.1
@@ -20,7 +20,7 @@ If no
 .Ar msgs
 are specified,
 .Nm
-reads file names from the standard input,
+reads filenames from the standard input,
 or uses the mails in the current sequence if used interactively.
 .Pp
 .Nm

--- a/man/mflag.1
+++ b/man/mflag.1
@@ -87,7 +87,7 @@ with the characters in
 .It Fl v
 Read Maildir mails from the standard input
 (or use the whole current sequence, if used interactively)
-and print the transformed list of file names.
+and print the transformed list of filenames.
 .Pp
 This can be used to keep the sequence intact in the case of renames.
 .El

--- a/man/mhdr.1
+++ b/man/mhdr.1
@@ -34,7 +34,7 @@ Only print the values of the headers in the colon-separated list
 .It Fl d
 Decode the headers according to RFC 2047.
 .It Fl H
-Prefix all output lines with the file name of the message, separated
+Prefix all output lines with the filename of the message, separated
 by a tab.
 .It Fl M
 Search for all occurrences of the headers

--- a/man/minc.1
+++ b/man/minc.1
@@ -16,7 +16,7 @@ by moving them from
 .Pa new
 to
 .Pa cur
-and adjusting the file names.
+and adjusting the filenames.
 .Pp
 By default, the new Maildir files are printed line by line.
 .Pp

--- a/man/mmsg.7
+++ b/man/mmsg.7
@@ -19,7 +19,7 @@ by the tools
 .Xr msort 1 ,
 .Xr mthread 1 .
 .Pp
-In general, you can always pass a file name as a message,
+In general, you can always pass a filename as a message,
 if it contains a
 .Sq Li \&/
 character.

--- a/man/mscan.1
+++ b/man/mscan.1
@@ -21,7 +21,7 @@ If no
 .Ar msgs
 are passed,
 .Nm
-reads file names from standard input,
+reads filenames from standard input,
 or uses the mails in the current sequence when used interactively
 (using a pager).
 .Pp
@@ -42,7 +42,7 @@ The options are as follows:
 .Bl -tag -width Ds
 .It Fl n
 Only print message numbers
-(or file names, if the message is not in the current sequence).
+(or filenames, if the message is not in the current sequence).
 .It Fl I
 Force ISO date output,
 even for

--- a/man/mseq.1
+++ b/man/mseq.1
@@ -54,9 +54,9 @@ was the current message.
 Fix non-existing filenames by searching for a message with the same
 Maildir id (but different flags).
 .It Fl r
-Remove leading indentation from the file names.
+Remove leading indentation from the filenames.
 .It Fl S
-Set the mail sequence to the file names passed on standard input.
+Set the mail sequence to the filenames passed on standard input.
 .It Fl A
 Like
 .Fl S ,
@@ -77,7 +77,7 @@ Symbolic link referring to the current message.
 (Default:
 .Pa ${MBLAZE:-$HOME/.mblaze}/cur )
 .It Ev MAILDOT
-When set to a file name, overrides the current message.
+When set to a filename, overrides the current message.
 (Prefer using
 .Fl c
 instead.)

--- a/man/mshow.1
+++ b/man/mshow.1
@@ -74,7 +74,7 @@ from the message
 .Ar msg
 into files.
 .Ar parts
-can be specified by number, file name or
+can be specified by number, filename or
 .Xr fnmatch 3
 pattern.
 .It Fl O Ar msg

--- a/man/msort.1
+++ b/man/msort.1
@@ -18,7 +18,7 @@ for the message argument syntax.
 .Pp
 If no messages are passed,
 .Nm
-will read file names from standard input,
+will read filenames from standard input,
 or use the default sequence if used interactively.
 .Pp
 .Nm
@@ -39,7 +39,7 @@ Sort by
 (modulo various variants of
 .Sq Li Re: ) .
 .It Fl F
-Sort by file name, using proper order for numbers in file names.
+Sort by filename, using proper order for numbers in filenames.
 .It Fl M
 Sort by message file modification time.
 .It Fl S

--- a/man/mthread.1
+++ b/man/mthread.1
@@ -19,7 +19,7 @@ for the message argument syntax.
 .Pp
 If no messages are passed,
 .Nm
-will read file names from standard input,
+will read filenames from standard input,
 or use the default sequence if used interactively.
 .Pp
 .Nm


### PR DESCRIPTION
- magrep.1
- mcom.1
- mexport.1
- mflag.1
- mhdr.1
- minc.1
- mmsg.7
- mscan.1
- mseq.1
- mshow.1
- msort.1
- mthread.1