### PR TITLE
seq: use of ^ should not produce a "parse" error when parent isn't found

### DIFF
--- a/seq.c
+++ b/seq.c
@@ -257,9 +257,9 @@ parse_thread(char *map, long a, long *starto, long *stopo)
 	if (state == 2) {
 		*starto = start;
 		*stopo = stop;
-		return 1;
+		return 0;
 	}
-	return 0;
+	return 1;
 }
 
 static int
@@ -292,14 +292,14 @@ parse_subthread(char *map, long a, long *stopo)
 	}
 
 	if (line < a)
-		return 0;
+		return 1;
 
 	if (minindent == -1)
 		stop = line;
 
 	*stopo = stop;
 
-	return 1;
+	return 0;
 }
 
 static int
@@ -326,14 +326,14 @@ parse_parent(char *map, long *starto, long *stopo)
 		if (line == *starto) {
 			if (previndent[indent-1]) {
 				*starto = *stopo = previndent[indent-1];
-				return 1;
-			} else {
 				return 0;
+			} else {
+				return 1;
 			}
 		}
 	}
 
-	return 0;
+	return 1;
 }
 
 static int
@@ -345,7 +345,7 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 	while (*a && *a != ':' && *a != '=' && *a != '_' && *a != '^') {
 		char *b = parse_relnum(a, cur, 0, lines, start);
 		if (a == b)
-			return 0;
+			return 1;
 		a = b;
 	}
 	if (*start == 0)
@@ -353,8 +353,8 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 
 	while (*a == '^') {
 		a++;
-		if (!parse_parent(map, start, stop))
-			return 0;
+		if (parse_parent(map, start, stop))
+			return 2;
 	}
 
 	if (*a == ':') {
@@ -364,7 +364,7 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 		} else {
 			char *b = parse_relnum(a, cur, *start, lines, stop);
 			if (a == b)
-				return 0;
+				return 1;
 		}
 	} else if (*a == '=') {
 		return parse_thread(map, *start, start, stop);
@@ -373,10 +373,10 @@ parse_range(char *map, char *a, long *start, long *stop, long cur, long lines)
 	} else if (!*a) {
 		*stop = *start;
 	} else {
-		return 0;
+		return 1;
 	}
 
-	return 1;
+	return 0;
 }
 
 void
@@ -427,9 +427,13 @@ blaze822_seq_next(char *map, char *range, struct blaze822_seq_iter *iter)
 		find_cur(map, iter);
 
 	if (!iter->start) {
-		if (!parse_range(map, range, &iter->start, &iter->stop,
-				 iter->cur, iter->lines)) {
+		int ret = parse_range(map, range, &iter->start, &iter->stop,
+				iter->cur, iter->lines);
+		if (ret == 1) {
 			fprintf(stderr, "can't parse range: %s\n", range);
+			return 0;
+		} else if (ret == 2) {
+			fprintf(stderr, "message not found for specified range: %s\n", range);
 			return 0;
 		}
 


### PR DESCRIPTION
This instead uses "message not found for specified range: %s\n" as the error message: that's the best I could think of and definitely an improvement over indicating a parse error but you may prefer something else.

This patch reverses the return status for parse_range along with associated functions.