### PR TITLE
Changes to mmsg.7

### DIFF
--- a/man/mmsg.7
+++ b/man/mmsg.7
@@ -5,28 +5,19 @@
 .Nm mmsg
 .Nd mblaze message argument syntax
 .Sh DESCRIPTION
-This manpage documents the message syntax used
-by the tools
-.Xr maddr 1 ,
-.Xr magrep 1 ,
-.Xr mflag 1 ,
-.Xr mhdr 1 ,
-.Xr mless 1 ,
-.Xr mrep 1 ,
-.Xr mscan 1 ,
-.Xr mseq 1 ,
-.Xr mshow 1 ,
-.Xr msort 1 ,
-.Xr mthread 1 .
+This document outlines the message syntax used by many
+of the tools in the
+.Xr mblaze 7
+message system.
 .Pp
-In general, you can always pass a filename as a message,
+In general, you can always specify a filename as a message,
 if it contains a
 .Sq Li \&/
 character.
-Use
+(Use
 .Sq Li \&./
-to prefix messages in the current directory.
-You can also pass a Maildir folder, which will be expanded
+to prefix messages in the current directory.)
+You can also specify a Maildir folder, which will be expanded
 to all messages in the
 .Pa cur/
 directory.
@@ -73,13 +64,13 @@ refers to the whole thread that contains
 .Sq Ar msg Ns Cm \&^
 refers to the parent of the message
 .Ar msg
-and may be repeated to refer to grand-parents.
+and may be repeated to refer to grandparents.
 .Sq Ar msg Ns Cm \&_
 refers to the subthread headed by
 .Ar msg
-(i.e. all messages below with more indentation).
+(i.e. all messages below, with more indentation).
 .Pp
-There are seven special shortcuts:
+The following special shortcuts may be used:
 .Bl -tag -width 3n
 .It Sq Li \&.
 refers to the current message.
@@ -107,5 +98,7 @@ refers to the current thread (like
 refers to the current subthread (like
 .Sq Li \&._ ) .
 .El
+.Sh SEE ALSO
+.Xr mblaze 7
 .Sh AUTHORS
 .An Leah Neukirchen Aq Mt leah@vuxu.org


### PR DESCRIPTION
- Remove listing of tools from DESCRIPTION
- pass -> specify
- Unhyphenate grandparents
- If we don't enumerate the shortcuts, it's easier to maintain
- Add SEE ALSO mblaze.7