### PR TITLE
fix double slashes

### DIFF
--- a/mlist.c
+++ b/mlist.c
@@ -185,6 +185,9 @@ listarg(char *arg)
 		iunseen = 0;
 		iflagged = 0;
 
+		if (arg[strlen(arg) - 1] == '/')
+			arg[strlen(arg) -1] = '\0';
+
 		snprintf(subdir, sizeof subdir, "%s/cur", arg);
 		if (stat(subdir, &st2) == 0) {
 			maildir = 1;


### PR DESCRIPTION
As of now, when calling mlist path/to/maildir/ if there is a trailing slash on the path, the output is path/to/maildir//cur/123mail. This checks if there is a trailing slash and removes it.