### PR TITLE
mrep: if List-Id header is present reply to list instead

### DIFF
--- a/mcom
+++ b/mcom
@@ -132,7 +132,8 @@ fi
 		if [ "$ng" ]; then
 			printf 'Newsgroups: %s\n' "$ng"
 		else
-			to=$(mhdr -h reply-to "$1")
+			to=$(mhdr -h list-id "$1")
+			[ -z "$to" ] && to=$(mhdr -h reply-to "$1")
 			[ -z "$to" ] && to=$(mhdr -h from "$1")
 			printf 'To: %s\n' "$to"
 			printf 'Cc: %s\n' \


### PR DESCRIPTION
This is useful for mailing lists. When replying to a mail sent to such
list you probably want to send your reply to the entire list.

---

Not sure if this should be the default behavior or if a command line flag should be introduced for this. 