### PR TITLE
mgenmid: fix off-by-one

### DIFF
--- a/mgenmid.c
+++ b/mgenmid.c
@@ -20,7 +20,7 @@ printb36(uint64_t x)
 	static char const base36[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 	char outbuf[16];
-	char *o = outbuf + sizeof outbuf;
+	char *o = outbuf + sizeof outbuf - 1;
 	*o = 0;
 
 	do { *--o = base36[x % 36]; } while (x /= 36);


### PR DESCRIPTION
When compiling mblaze with `make CFLAGS=-Os` mgenid segfaults  here. Inspecting the coredumb with gdb yields the following:

```
(gdb) bt                                                                                                                                                                 
#0  a_crash () at ./arch/x86_64/atomic_arch.h:108                                                                                                                        
#1  __stack_chk_fail () at src/env/__stack_chk_fail.c:17
#2  0x0000005b5987c61f in printb36 (x=<optimized out>) at mgenmid.c:28
#3  0x0000005b5987c3df in main () at mgenmid.c:108
```

After looking at the `printb36` function I noticed that it seems to write outside the buffer bounds due to an off-by-one. This patch fixes this problem.
