### PR TITLE
mquote: make sed expression to strip signature work with busybox sed

### DIFF
--- a/mquote
+++ b/mquote
@@ -7,6 +7,6 @@
 
 printf '%s wrote:\n' "$from"
 mshow -R "$1" |
-	sed -n '/^-- $/!p;//q' |                   # strip signature
+	sed -n '/^-- $/,$!p'   |                   # strip signature
 	sed -e :a -e '/^\n*$/{$d;N;ba' -e '}' |    # strip empty lines
 	sed 's/^/> /'                              # prefix with >


### PR DESCRIPTION
Not sure if compatibility with non-GNU sed version is a goal of this project but you seem to have fixed non-POSIX sed usage [in the past](https://github.com/chneukirchen/mblaze/commit/b0d61b82750f7466349e34e8c1831664e701a460). Therefore I wanted to inform you that  mquote doesn't work with busybox sed because the sed expression to strip the signature seems to strip all lines except the first one with busybox sed. For example:

```
$ printf "foo\nbar\n-- \nbaz" | sed -n '/^-- $/!p;//q'
foo
```

I am not a sed magician myself but I came up with a solution that seems to work with busybox sed as well. Not sure if it is ideal though...

 