### PR TITLE
magrep: keep threading while matching body

### DIFF
--- a/magrep.c
+++ b/magrep.c
@@ -106,11 +106,12 @@ match_part(int depth, struct message *msg, char *body, size_t bodylen)
 void
 match_body(char *file)
 {
-	curfile = file;
-	while (*curfile == ' ' || *curfile == '\t')
-		curfile++;
+	char *filename;
+	filename = curfile = file;
+	while (*filename == ' ' || *filename == '\t')
+		filename++;
 
-	struct message *msg = blaze822_file(curfile);
+	struct message *msg = blaze822_file(filename);
 	if (!msg)
 		return;
 


### PR DESCRIPTION
Currently `magrep` keeps the threading for all matching modes except if it matches the bodies of mails.
This patch adds a char pointer on the stack to remove the spaces from the name to open it with `blaze822_file` and keeps the global `curfile` pointer as it is, `curfile` is used later to print the path of the matching mail.

```
mblaze@pi$ magrep subject:dmenu
 /home/duncan/mail/1505313797.1422_502.tux,U=41582:2,T
 /home/duncan/mail/1505313797.1422_503.tux,U=41583:2,
 /home/duncan/mail/1505402355.860_20.tux,U=41680:2,
mblaze@pi$ magrep /:dmenu
/home/duncan/mail/1505313797.1422_503.tux,U=41583:2,
mblaze@pi$ ./magrep /:dmenu
 /home/duncan/mail/1505313797.1422_503.tux,U=41583:2,
```