### PR TITLE
changes to maddr.1

### DIFF
--- a/man/maddr.1
+++ b/man/maddr.1
@@ -41,10 +41,10 @@ for mail addresses.
 By default,
 .Nm
 searches the
-.Sq Li "from\&:sender\&:reply-to\&:to\&:cc\&:bcc"
+.Sq Li from\&:sender\&:reply-to\&:to\&:cc\&:bcc
 .Ar headers
 and their respective
-.Sq Li "resent\&-"
+.Sq Li resent\&-
 variants, if any.
 .El
 .Sh EXIT STATUS

--- a/man/maddr.1
+++ b/man/maddr.1
@@ -11,39 +11,41 @@
 .Op Ar msgs\ ...
 .Sh DESCRIPTION
 .Nm
-prints, one per line, all mail addresses found in the
+prints, separated by newlines, all mail addresses found in the
 .Ar headers
 of the specified
 .Ar msgs .
-See
+(See
 .Xr mmsg 7
-for the message argument syntax.
+for the message argument syntax.)
 .Pp
 If no
 .Ar msgs
-are specified,
-and
+are specified and
 .Nm
 is used interactively,
 .Nm
-will default to the current sequence.
-Otherwise,
+will operate on the current sequence by default.
+Otherwise
 .Nm
-will read filenames from standard input.
+will read filenames from the standard input.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
 .It Fl a
-Only print the addr-spec part of the address, not the display name.
+Only print the addr-spec component, not the display name.
 .It Fl h Ar headers
-Only search the colon-separated list of
+Search the colon-separated list of
 .Ar headers
 for mail addresses.
-Default:
-.Sq Li from\&:sender\&:reply\&-to\&:to\&:cc\&:bcc\&:
+By default,
+.Nm
+searches the
+.Sq Li "from:sender:reply-to:to:cc:bcc"
+.Ar headers
 and their respective
-.Sq Li resent\&-
-variants.
+.Sq Li "resent-"
+variants, if any.
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/man/maddr.1
+++ b/man/maddr.1
@@ -41,10 +41,10 @@ for mail addresses.
 By default,
 .Nm
 searches the
-.Sq Li "from:sender:reply-to:to:cc:bcc"
+.Sq Li "from\&:sender\&:reply-to\&:to\&:cc\&:bcc"
 .Ar headers
 and their respective
-.Sq Li "resent-"
+.Sq Li "resent\&-"
 variants, if any.
 .El
 .Sh EXIT STATUS


### PR DESCRIPTION
- 'separated by newlines' instead of 'one per line'
- Enclose 'See mmsg(7)...' in brackets; this will be
  done in all other pages where this line appears
- Remove trailing ':' from default headers list