### PR TITLE
maddr.1: update wording

### DIFF
--- a/man/maddr.1
+++ b/man/maddr.1
@@ -11,39 +11,40 @@
 .Op Ar msgs\ ...
 .Sh DESCRIPTION
 .Nm
-prints, one per line, all mail addresses found in the
+prints, separated by newlines, all mail addresses found in the
 .Ar headers
 of the specified
 .Ar msgs .
-See
+.Po See
 .Xr mmsg 7
 for the message argument syntax.
+.Pc
 .Pp
 If no
 .Ar msgs
-are specified,
+are specified
 and
 .Nm
 is used interactively,
 .Nm
-will default to the current sequence.
+will operate on the current sequence by default.
 Otherwise,
 .Nm
-will read filenames from standard input.
+will read filenames from the standard input.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
 .It Fl a
-Only print the addr-spec part of the address, not the display name.
+Only print the addr-spec address, not the display name.
 .It Fl h Ar headers
 Only search the colon-separated list of
 .Ar headers
 for mail addresses.
 Default:
-.Sq Li from\&:sender\&:reply\&-to\&:to\&:cc\&:bcc\&:
+.Sq Li from\&:sender\&:reply\&-to\&:to\&:cc\&:bcc
 and their respective
 .Sq Li resent\&-
-variants.
+variants, if any.
 .El
 .Sh EXIT STATUS
 .Ex -std

--- a/man/maddr.1
+++ b/man/maddr.1
@@ -41,7 +41,7 @@ Only search the colon-separated list of
 .Ar headers
 for mail addresses.
 Default:
-.Sq Li from\&:sender\&:reply\&-to\&:to\&:cc\&:bcc
+.Sq Li from\&:sender\&:reply\&-to\&:to\&:cc\&:bcc\&:
 and their respective
 .Sq Li resent\&-
 variants, if any.


### PR DESCRIPTION
- 'separated by newlines' seems more idiomatic than 'one per line'
- introduce parens for 'See mmsg(7)...'. This phrase ('See mmsg(7)...') appears in a lot of the man pages, and I just want to pin down its usage style a bit. So I'm proposing using it in brackets. In one or two of the other man pages, I'll also be proposing to move it from where it is currently.
- lose comma, and trailing semi-colon, unless you say we *need* the trailing semi-colon in `from\&:sender\&:reply\&-to\&:to\&:cc\&:bcc\&:`?
- 'the' standard input. Standard input appears in a few man pages, and I would like to standardise on using 'the' standard (input|output), as God intended.
- 'addr-spec address' is as per RFC 2822, so I don't think there's any need for 'addr-spec part of the address' or 'the addr-spec component' or similar
