### PR TITLE
Correct reference to SOURCE_DATE_EPOCH

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -38,7 +38,7 @@ mmime : slurp.o
 minc mlist : squeeze_slash.o
 
 museragent: FRC
-	@test -n "$$SOURCE_TIME_EPOCH" || BUILDDATE=$$(date '+ (%Y-%m-%d)'); \
+	@test -n "$$SOURCE_DATE_EPOCH" || BUILDDATE=$$(date '+ (%Y-%m-%d)'); \
 		printf '#!/bin/sh\nprintf "User-Agent: mblaze/%s%s\\n"\n' \
 		"$$({ git describe --always --dirty 2>/dev/null || cat VERSION; } | sed 's/^v//')" \
 		"$$BUILDDATE" >$@


### PR DESCRIPTION
It's `DATE`, not `TIME`… https://reproducible-builds.org/specs/source-date-epoch/

Originally filed in @Debian as https://bugs.debian.org/907537