### PR TITLE
mpick: Increase buffer for decoded header field

### DIFF
--- a/mpick.c
+++ b/mpick.c
@@ -809,7 +809,7 @@ msg_hdr(struct mailinfo *m, const char *h)
 	if (!m->msg || !(b = blaze822_chdr(m->msg, h)))
 		goto err;
 
-	char buf[100];
+	char buf[4096];
 	blaze822_decode_rfc2047(buf, b, sizeof buf - 1, "UTF-8");
 	if (!*buf)
 		goto err;


### PR DESCRIPTION
When using:

  $ mlist maildir | mpick -t '"cc" ~~ "*vger.kernel.org*"'

with a maildir containing mails from Linux Mailing List, not all
messages were picked correctly. It turned out that the reason was
small (100 bytes) buffer for header fields.

Increase header field buffer to 4096, which is the most commonly used
value.