### PR TITLE
mscan: don't write to stderr unless an error occurred

### DIFF
--- a/mscan.c
+++ b/mscan.c
@@ -563,12 +563,10 @@ main(int argc, char *argv[])
 				fflag = v;
 	}
 
-	long i;
 	if (argc == optind && isatty(0))
-		i = blaze822_loop1(":", oneline);
+		blaze822_loop1(":", oneline);
 	else
-		i = blaze822_loop(argc-optind, argv+optind, oneline);
-	fprintf(stderr, "%ld mails scanned\n", i);
+		blaze822_loop(argc-optind, argv+optind, oneline);
 
 	if (pid1 > 0)
 		pipeclose(pid1);


### PR DESCRIPTION
Maybe I am just ignorant and stupid (or using mscan wrong) but the fact that the amount of messages scanned is always written to stderr confuses my pager and doesn't seem useful at all to me.

Opening a PR to figure out if there is a specific reason for this.