### PR TITLE
Quote variables and subshells in shell scripts

### DIFF
--- a/contrib/mencrypt
+++ b/contrib/mencrypt
@@ -15,10 +15,10 @@ trap "rm -rf '$TMPD'" INT TERM EXIT
 
 awk '/^$/,0' "$1" |
 	mmime |
-	gpg2 $key --armor --encrypt --sign $FLAGS -o $TMPD/msg.asc ||
+	gpg2 "$key" --armor --encrypt --sign $FLAGS -o "$TMPD/msg.asc" ||
 	exit $?
 
-printf 'Version: 1\n' >$TMPD/version
+printf 'Version: 1\n' >"$TMPD/version"
 
 {
 	sed '/^$/q' "$1"

--- a/mcom
+++ b/mcom
@@ -76,13 +76,13 @@ do_mime() {
 	if needs_multipart "$draft"; then
 		(
 			IFS=$NL
-			msed '/attach/d' $draft
-			for f in $(mhdr -M -h attach $draft); do
+			msed '/attach/d' "$draft"
+			for f in "$(mhdr -M -h attach "$draft")"; do
 				printf '#%s %s\n' \
 				       "$(file -Lbi $f | sed 's/ //g')" \
 				       "$f"
 			done
-		) | mmime >$draftmime
+		) | mmime >"$draftmime"
 	else
 		mmime -r <"$draft" >"$draftmime"
 	fi
@@ -381,7 +381,7 @@ fi
 			cat "$SIGNATURE"
 		fi
 	esac
-} >$draft
+} >"$draft"
 
 automime=
 c=$defaultc
@@ -401,15 +401,15 @@ while :; do
 			;;
 		esac
 
-		if [ -e $draftmime ]; then
+		if [ -e "$draftmime" ]; then
 			if [ $draft -ot $draftmime ] || [ "$automime" = 1 ]; then
-				stampdate $draftmime
-				if $sendmail <$draftmime; then
+				stampdate "$draftmime"
+				if $sendmail <"$draftmime"; then
 					if [ "$outbox" ]; then
-						mv $draftmime $draft
-						mflag -d -S $draft
+						mv "$draftmime" "$draft"
+						mflag -d -S "$draft"
 					else
-						rm $draft $draftmime
+						rm "$draft" "$draftmime"
 					fi
 				else
 					printf '%s\n' "mcom: $sendmail failed, kept draft $draft"
@@ -421,13 +421,13 @@ while :; do
 				continue
 			fi
 		else
-			if mmime -c <$draft; then
-				stampdate $draft
-				if $sendmail <$draft; then
+			if mmime -c <"$draft"; then
+				stampdate "$draft"
+				if $sendmail <"$draft"; then
 					if [ "$outbox" ]; then
-						mflag -d -S $draft
+						mflag -d -S "$draft"
 					else
-						rm $draft
+						rm "$draft"
 					fi
 				else
 					printf '%s\n' "mcom: $sendmail failed, kept draft $draft"
@@ -449,23 +449,23 @@ while :; do
 		exit 0
 		;;
 	c|cancel)
-		stampdate $draft
+		stampdate "$draft"
 		printf '%s\n' "mcom: cancelled draft $draft"
 		exit 1
 		;;
 	m|mime)
 		do_mime
-		mshow -t $draftmime
+		mshow -t "$draftmime"
 		c=
 		;;
 	e|edit)
 		c=
-		if ! ${EDITOR:-vi} $draft; then
+		if ! ${EDITOR:-vi} "$draft"; then
 			c=d
 		else
-			if checksensible $draft; then
-				stripempty $draft
-				if mmime -c <$draft && ! needs_multipart $draft; then
+			if checksensible "$draft"; then
+				stripempty "$draft"
+				if mmime -c <"$draft" && ! needs_multipart "$draft"; then
 					automime=
 				else
 					automime=1
@@ -477,8 +477,8 @@ while :; do
 		fi
 		;;
 	justsend)
-		stripempty $draft
-		if mmime -c <$draft && ! needs_multipart $draft; then
+		stripempty "$draft"
+		if mmime -c <"$draft" && ! needs_multipart "$draft"; then
 			automime=
 		else
 			automime=1
@@ -487,26 +487,26 @@ while :; do
 		c=send
 		;;
 	d|delete)
-		rm -i $draft
-		if ! [ -f $draft ]; then
-			rm -f $draftmime
+		rm -i "$draft"
+		if ! [ -f "$draft" ]; then
+			rm -f "$draftmime"
 			printf '%s\n' "mcom: deleted draft $draft"
 			exit 0
 		fi
 		c=
 		;;
 	sign)
-		msign $draft >$draftmime
-		mshow -t $draftmime
+		msign "$draft" >"$draftmime"
+		mshow -t "$draftmime"
 		c=
 		;;
 	encrypt)
-		mencrypt $draft >$draftmime
-		mshow -t $draftmime
+		mencrypt "$draft" >"$draftmime"
+		mshow -t "$draftmime"
 		c=
 		;;
 	show)
-		if [ -e $draftmime ]; then
+		if [ -e "$draftmime" ]; then
 			mshow "$draftmime"
 		else
 			mshow "$draft"

--- a/mless
+++ b/mless
@@ -37,9 +37,9 @@ if [ "$1" = --filter ]; then
 			mshow "$2"
 		fi | mcolor
 	else
-		mseq -r $2
+		mseq -r "$2"
 		echo
-		cat "$(mseq -r $2)"
+		cat "$(mseq -r "$2")"
 	fi
 	exit $?
 fi
@@ -64,12 +64,12 @@ nl="
 export MLESS_RAW=0
 export MLESS_HTML=0
 while :; do
-	if [ -f $MBLAZE/mless ]; then
-		export LESSKEY=$MBLAZE/mless
-	elif [ -f $HOME/.mblaze/mless ]; then
-		export LESSKEY=$HOME/.mblaze/mless
-	elif [ -f $HOME/.mless ]; then
-		export LESSKEY=$HOME/.mless
+	if [ -f "$MBLAZE/mless" ]; then
+		export LESSKEY="$MBLAZE/mless"
+	elif [ -f "$HOME/.mblaze/mless" ]; then
+		export LESSKEY="$HOME/.mblaze/mless"
+	elif [ -f "$HOME/.mless" ]; then
+		export LESSKEY="$HOME/.mless"
 	fi
 	LESSOPEN="|$0 --filter %s" \
 		less -Ps"mless %f?m (message %i of %m).." -R \


### PR DESCRIPTION
I noticed, that there was something wrong with the quoting in `mcom`. I got errors relating to my `Outbox` (see `man mblaze-profile`), when this maildir contained spaces.

I found that correct quoting was missing in many places. I tried fixing the quoting wherever I was able to. I'm sure I still missed some (especially in `contrib/`). `mcom` now works when there are spaces in the `Outbox` maildir.

I'd like to remind all contributers, that quoting in shell scripts is essential for security. After all we are dealing with a mail client here. I'm no expert on the matter myself, but I think it's extra important to be careful when writing shell scripts for this project. While reading on the subject, I even found a [stackexchange thread](https://unix.stackexchange.com/questions/171346/), where **it is suggested to not use shell scripts** in security-sensitive contexts at all.

Hint: I used this expression to find potentially interesting places in mcom (and the other shell scripts): `grep -n "$." mcom | grep -v "\"$." | vim -`