### PR TITLE
Improve security when using gpg

### DIFF
--- a/mcom
+++ b/mcom
@@ -70,16 +70,26 @@ stripempty() {
 draft_to_sketch() {
 	msg_sketch=$(mktemp -t mcom.XXXXXX)
 	if [ -f "$draft" ]; then
+                # TODO: If $draft is an encrypted message it needs
+                # to be decrypted first. Make sure, that the decrypted
+                # message can later be correctly encrypted again.
 		cp -f "$draft" "$msg_sketch"
 	fi
 }
 
 sketch_to_draft() {
+	tmp=$(mktemp -t mcom.XXXXXX)
 	if ! mmime -c <"$msg_sketch" || needs_multipart "$msg_sketch"; then
-		do_mime
+		do_mime "$msg_sketch" >"$tmp"
 	else
-		cp -f "$msg_sketch" "$draft"
+		cp "$msg_sketch" "$tmp"
 	fi
+	if [ -n "$encrypt" ]; then
+		mencrypt "$tmp" >"$draft"
+	else
+		cp -f "$tmp" "$draft"
+	fi
+	rm "$tmp"
 }
 
 needs_multipart() {
@@ -88,18 +98,18 @@ needs_multipart() {
 }
 
 do_mime() {
-	if needs_multipart "$msg_sketch"; then
+	if needs_multipart "$1"; then
 		(
 			IFS=$NL
-			msed '/attach/d' "$msg_sketch"
-			for f in $(mhdr -M -h attach "$msg_sketch"); do
+			msed '/attach/d' "$1"
+			for f in $(mhdr -M -h attach "$1"); do
 				printf '#%s %s\n' \
 				       "$(file -Lbi "$f" | sed 's/ //g')" \
 				       "$f"
 			done
-		) | mmime >"$draft"
+		) | mmime
 	else
-		mmime -r <"$msg_sketch" >"$draft"
+		mmime -r <"$1"
 	fi
 }
 
@@ -115,6 +125,7 @@ defaultc=e
 hdrs=
 resume=
 noquote=
+encrypt=
 case "$0" in
 *mcom*)
 	hdr=to
@@ -145,6 +156,9 @@ case "$0" in
 		-send)
 			defaultc=justsend
 			shift;;
+		-encrypt)
+			encrypt=1
+			shift;;
 		-??*)
 			hdr=${1#-}
 			shift;;
@@ -171,6 +185,9 @@ case "$0" in
 		-send)
 			defaultc=justsend
 			shift;;
+		-encrypt)
+			encrypt=1
+			shift;;
 		-??*)
 			hdr=${1#-}
 			shift;;
@@ -194,6 +211,9 @@ case "$0" in
 			break;;
 		-send)
 			defaultc=justsend
+			shift;;
+		-encrypt)
+			encrypt=1
 			shift;;
 		-??*)
 			hdr=${1#-}
@@ -222,6 +242,9 @@ case "$0" in
 		-noquote)
 			noquote=1
 			shift;;
+		-encrypt)
+			encrypt=1
+			shift;;
 		-??*)
 			hdr=${1#-}
 			shift;;
@@ -239,6 +262,9 @@ case "$0" in
 esac
 
 hdrs="$(printf '%s\n' "${hdrs#$NL}" | mhdr /dev/stdin)"
+
+# TODO: When resuming: Ask the user if `encrypt` shall be set, when
+# the existing draft is already encrypted.
 
 outbox=$(mhdr -h outbox "$MBLAZE/profile")
 if [ -z "$outbox" ]; then

--- a/mcom
+++ b/mcom
@@ -86,6 +86,8 @@ sketch_to_draft() {
 	fi
 	if [ -n "$encrypt" ]; then
 		mencrypt "$tmp" >"$draft"
+	elif [ -n "$sign" ]; then
+		msign "$tmp" >"$draft"
 	else
 		cp -f "$tmp" "$draft"
 	fi
@@ -126,6 +128,7 @@ hdrs=
 resume=
 noquote=
 encrypt=
+sign=
 case "$0" in
 *mcom*)
 	hdr=to
@@ -159,6 +162,9 @@ case "$0" in
 		-encrypt)
 			encrypt=1
 			shift;;
+		-sign)
+			sign=1
+			shift;;
 		-??*)
 			hdr=${1#-}
 			shift;;
@@ -188,6 +194,9 @@ case "$0" in
 		-encrypt)
 			encrypt=1
 			shift;;
+		-sign)
+			sign=1
+			shift;;
 		-??*)
 			hdr=${1#-}
 			shift;;
@@ -214,6 +223,9 @@ case "$0" in
 			shift;;
 		-encrypt)
 			encrypt=1
+			shift;;
+		-sign)
+			sign=1
 			shift;;
 		-??*)
 			hdr=${1#-}
@@ -244,6 +256,9 @@ case "$0" in
 			shift;;
 		-encrypt)
 			encrypt=1
+			shift;;
+		-sign)
+			sign=1
 			shift;;
 		-??*)
 			hdr=${1#-}

--- a/mcom
+++ b/mcom
@@ -67,6 +67,21 @@ stripempty() {
 	mv "$tmp" "$1"
 }
 
+draft_to_sketch() {
+	msg_sketch=$(mktemp -t mcom.XXXXXX)
+	if [ -f "$draft" ]; then
+		cp -f "$draft" "$msg_sketch"
+	fi
+}
+
+sketch_to_draft() {
+	if ! mmime -c <"$msg_sketch" || needs_multipart "$msg_sketch"; then
+		do_mime
+	else
+		cp -f "$msg_sketch" "$draft"
+	fi
+}
+
 needs_multipart() {
 	mhdr -h attach "$1" >/dev/null ||
 		grep -q '^#[^ ]*/[^ ]* ' "$1"
@@ -115,15 +130,15 @@ case "$0" in
 			resume=1
 			if [ "$#" -gt 0 ]; then
 				case "$1" in
-					/*|./*) msg_sketch="$1";;
-					*) msg_sketch="./$1";;
+					/*|./*) draft="$1";;
+					*) draft="./$1";;
 				esac
-				if ! [ -f "$msg_sketch" ]; then
+				if ! [ -f "$draft" ]; then
 					printf 'mcom: no such draft %s\n' \
-					       "$msg_sketch" 1>&2
+					       "$draft" 1>&2
 					exit 1
 				fi
-				echo "using draft $msg_sketch"
+				echo "using draft $draft"
 				shift
 			fi
 			;;
@@ -232,23 +247,23 @@ if [ -z "$outbox" ]; then
 		while [ -f "snd.$i" ]; do
 			i=$((i+1))
 		done
-		msg_sketch="./snd.$i"
-	elif [ -z "$msg_sketch" ]; then
-		msg_sketch=$(ls -1t ./snd.*[0-9] | sed 1q)
+		draft="./snd.$i"
+	elif [ -z "$draft" ]; then
+		draft=$(ls -1t ./snd.*[0-9] | sed 1q)
 	fi
-	draft="$msg_sketch.mime"
 else
 	if [ -z "$resume" ]; then
-		msg_sketch="$(true | mdeliver -v -c -XD "$outbox")"
-		if [ -z "$msg_sketch" ]; then
+		draft="$(true | mdeliver -v -c -XD "$outbox")"
+		if [ -z "$draft" ]; then
 			printf '%s\n' "$0: failed to create draft in outbox $outbox." 1>&2
 			exit 1
 		fi
-	elif [ -z "$msg_sketch" ]; then
-		msg_sketch=$(mlist -D "$outbox" | msort -r -M | sed 1q)
+	elif [ -z "$draft" ]; then
+		draft=$(mlist -D "$outbox" | msort -r -M | sed 1q)
 	fi
-	draft="$(printf '%s\n' "$msg_sketch" | sed 's,\(.*\)/cur/,\1/tmp/mime-,')"
 fi
+draft_to_sketch
+trap 'rm -f "$msg_sketch"; trap "" EXIT' INT TERM EXIT
 
 [ -z "$resume" ] &&
 {
@@ -383,7 +398,6 @@ fi
 	esac
 } >"$msg_sketch"
 
-automime=
 c=$defaultc
 while :; do
 	case "$c" in
@@ -401,43 +415,17 @@ while :; do
 			;;
 		esac
 
-		if [ -e "$draft" ]; then
-			if [ "$msg_sketch" -ot "$draft" ] || [ "$automime" = 1 ]; then
-				stampdate "$draft"
-				if $sendmail <"$draft"; then
-					if [ "$outbox" ]; then
-						mv "$draft" "$msg_sketch"
-						mflag -d -S "$msg_sketch"
-					else
-						rm "$msg_sketch" "$draft"
-					fi
-				else
-					printf '%s\n' "mcom: $sendmail failed, kept draft $msg_sketch"
-					exit 2
-				fi
+		sketch_to_draft
+		stampdate "$draft"
+		if $sendmail <"$draft"; then
+			if [ "$outbox" ]; then
+				mflag -d -S "$draft"
 			else
-				printf 'mcom: re-run mmime first.\n'
-				c=
-				continue
+				rm "$draft"
 			fi
 		else
-			if mmime -c <"$msg_sketch"; then
-				stampdate "$msg_sketch"
-				if $sendmail <"$msg_sketch"; then
-					if [ "$outbox" ]; then
-						mflag -d -S "$msg_sketch"
-					else
-						rm "$msg_sketch"
-					fi
-				else
-					printf '%s\n' "mcom: $sendmail failed, kept draft $msg_sketch"
-					exit 2
-				fi
-			else
-				printf '%s\n' "mcom: message needs to be MIME-encoded first."
-				c=
-				continue
-			fi
+			printf '%s\n' "mcom: $sendmail failed, kept draft $draft"
+			exit 2
 		fi
 
 		case "$0" in
@@ -449,14 +437,9 @@ while :; do
 		exit 0
 		;;
 	c|cancel)
-		stampdate "$msg_sketch"
-		printf '%s\n' "mcom: cancelled draft $msg_sketch"
+		stampdate "$draft"
+		printf '%s\n' "mcom: cancelled draft $draft"
 		exit 1
-		;;
-	m|mime)
-		do_mime
-		mshow -t "$draft"
-		c=
 		;;
 	e|edit)
 		c=
@@ -465,46 +448,30 @@ while :; do
 		else
 			if checksensible "$msg_sketch"; then
 				stripempty "$msg_sketch"
-				if mmime -c <"$msg_sketch" && ! needs_multipart "$msg_sketch"; then
-					automime=
-				else
-					automime=1
-					do_mime
-				fi
 			else
 				printf '\n'
 			fi
 		fi
+		sketch_to_draft
 		;;
 	justsend)
 		stripempty "$msg_sketch"
-		if mmime -c <"$msg_sketch" && ! needs_multipart "$msg_sketch"; then
-			automime=
-		else
-			automime=1
-			do_mime
-		fi
 		c=send
 		;;
 	d|delete)
-		rm -i "$msg_sketch"
-		if ! [ -f "$msg_sketch" ]; then
-			rm -f "$draft"
-			printf '%s\n' "mcom: deleted draft $msg_sketch"
+		rm -i "$draft"
+		if ! [ -f "$draft" ]; then
+			printf '%s\n' "mcom: deleted draft $draft"
 			exit 0
 		fi
 		c=
 		;;
 	show)
-		if [ -e "$draft" ]; then
-			mshow "$draft"
-		else
-			mshow "$msg_sketch"
-		fi
+		mshow "$draft"
 		c=
 		;;
 	*)
-		printf 'What now? (%s[s]end, [c]ancel, [d]elete, [e]dit, [m]ime) ' "${automime:+mime and }"
+		printf 'What now? ([s]end, [c]ancel, [d]elete, [e]dit) '
 		read -r c
 		;;
 	esac

--- a/mcom
+++ b/mcom
@@ -28,6 +28,20 @@ msgid() {
 	mgenmid 2>/dev/null | sed 's/^/Message-Id: /'
 }
 
+# $TMPDIR is used by mktemp().
+set_tmpdir() {
+	if [ -d /dev/shm -a -w /dev/shm ]; then
+		export TMPDIR='/dev/shm'
+	elif [ -n "$encrypt" ]; then
+		printf '/dev/shm is unavailable on your system. Instead '
+		printf '$TMPDIR or /tmp \nwill be used to temporarily '
+		printf 'store unencrypted data.\n'
+		printf 'Do you wish to continue? [Y/n] '
+		read -r c
+		[ -z "$c" -o "$c" = "y" -o "$c" = "Y" ] || exit 1
+	fi
+}
+
 stampdate() {
 	if ! mhdr -h date "$1" >/dev/null; then
 		tmp=$(mktemp -t mcom.XXXXXX)
@@ -275,6 +289,7 @@ case "$0" in
 	[ "$#" -eq 0 ] && set -- .
 	;;
 esac
+set_tmpdir
 
 hdrs="$(printf '%s\n' "${hdrs#$NL}" | mhdr /dev/stdin)"
 

--- a/mcom
+++ b/mcom
@@ -73,18 +73,18 @@ needs_multipart() {
 }
 
 do_mime() {
-	if needs_multipart "$draft"; then
+	if needs_multipart "$msg_sketch"; then
 		(
 			IFS=$NL
-			msed '/attach/d' "$draft"
-			for f in $(mhdr -M -h attach "$draft"); do
+			msed '/attach/d' "$msg_sketch"
+			for f in $(mhdr -M -h attach "$msg_sketch"); do
 				printf '#%s %s\n' \
 				       "$(file -Lbi "$f" | sed 's/ //g')" \
 				       "$f"
 			done
-		) | mmime >"$draftmime"
+		) | mmime >"$draft"
 	else
-		mmime -r <"$draft" >"$draftmime"
+		mmime -r <"$msg_sketch" >"$draft"
 	fi
 }
 
@@ -115,15 +115,15 @@ case "$0" in
 			resume=1
 			if [ "$#" -gt 0 ]; then
 				case "$1" in
-					/*|./*) draft="$1";;
-					*) draft="./$1";;
+					/*|./*) msg_sketch="$1";;
+					*) msg_sketch="./$1";;
 				esac
-				if ! [ -f "$draft" ]; then
+				if ! [ -f "$msg_sketch" ]; then
 					printf 'mcom: no such draft %s\n' \
-					       "$draft" 1>&2
+					       "$msg_sketch" 1>&2
 					exit 1
 				fi
-				echo "using draft $draft"
+				echo "using draft $msg_sketch"
 				shift
 			fi
 			;;
@@ -232,22 +232,22 @@ if [ -z "$outbox" ]; then
 		while [ -f "snd.$i" ]; do
 			i=$((i+1))
 		done
-		draft="./snd.$i"
-	elif [ -z "$draft" ]; then
-		draft=$(ls -1t ./snd.*[0-9] | sed 1q)
+		msg_sketch="./snd.$i"
+	elif [ -z "$msg_sketch" ]; then
+		msg_sketch=$(ls -1t ./snd.*[0-9] | sed 1q)
 	fi
-	draftmime="$draft.mime"
+	draft="$msg_sketch.mime"
 else
 	if [ -z "$resume" ]; then
-		draft="$(true | mdeliver -v -c -XD "$outbox")"
-		if [ -z "$draft" ]; then
+		msg_sketch="$(true | mdeliver -v -c -XD "$outbox")"
+		if [ -z "$msg_sketch" ]; then
 			printf '%s\n' "$0: failed to create draft in outbox $outbox." 1>&2
 			exit 1
 		fi
-	elif [ -z "$draft" ]; then
-		draft=$(mlist -D "$outbox" | msort -r -M | sed 1q)
+	elif [ -z "$msg_sketch" ]; then
+		msg_sketch=$(mlist -D "$outbox" | msort -r -M | sed 1q)
 	fi
-	draftmime="$(printf '%s\n' "$draft" | sed 's,\(.*\)/cur/,\1/tmp/mime-,')"
+	draft="$(printf '%s\n' "$msg_sketch" | sed 's,\(.*\)/cur/,\1/tmp/mime-,')"
 fi
 
 [ -z "$resume" ] &&
@@ -381,19 +381,19 @@ fi
 			cat "$SIGNATURE"
 		fi
 	esac
-} >"$draft"
+} >"$msg_sketch"
 
 automime=
 c=$defaultc
 while :; do
 	case "$c" in
 	s|send)
-		case "$(mhdr -h newsgroups "$draft")" in
+		case "$(mhdr -h newsgroups "$msg_sketch")" in
 			*gmane.*) sendmail="mblow -s news.gmane.org";;
 			*.*) sendmail="mblow";;
 		esac
 
-		resent="$(maddr -h resent-to "$draft")"
+		resent="$(maddr -h resent-to "$msg_sketch")"
 		case "$resent" in
 		?*)
 			sendmail=$(mhdr -h sendmail "$MBLAZE/profile")
@@ -401,18 +401,18 @@ while :; do
 			;;
 		esac
 
-		if [ -e "$draftmime" ]; then
-			if [ "$draft" -ot "$draftmime" ] || [ "$automime" = 1 ]; then
-				stampdate "$draftmime"
-				if $sendmail <"$draftmime"; then
+		if [ -e "$draft" ]; then
+			if [ "$msg_sketch" -ot "$draft" ] || [ "$automime" = 1 ]; then
+				stampdate "$draft"
+				if $sendmail <"$draft"; then
 					if [ "$outbox" ]; then
-						mv "$draftmime" "$draft"
-						mflag -d -S "$draft"
+						mv "$draft" "$msg_sketch"
+						mflag -d -S "$msg_sketch"
 					else
-						rm "$draft" "$draftmime"
+						rm "$msg_sketch" "$draft"
 					fi
 				else
-					printf '%s\n' "mcom: $sendmail failed, kept draft $draft"
+					printf '%s\n' "mcom: $sendmail failed, kept draft $msg_sketch"
 					exit 2
 				fi
 			else
@@ -421,16 +421,16 @@ while :; do
 				continue
 			fi
 		else
-			if mmime -c <"$draft"; then
-				stampdate "$draft"
-				if $sendmail <"$draft"; then
+			if mmime -c <"$msg_sketch"; then
+				stampdate "$msg_sketch"
+				if $sendmail <"$msg_sketch"; then
 					if [ "$outbox" ]; then
-						mflag -d -S "$draft"
+						mflag -d -S "$msg_sketch"
 					else
-						rm "$draft"
+						rm "$msg_sketch"
 					fi
 				else
-					printf '%s\n' "mcom: $sendmail failed, kept draft $draft"
+					printf '%s\n' "mcom: $sendmail failed, kept draft $msg_sketch"
 					exit 2
 				fi
 			else
@@ -449,23 +449,23 @@ while :; do
 		exit 0
 		;;
 	c|cancel)
-		stampdate "$draft"
-		printf '%s\n' "mcom: cancelled draft $draft"
+		stampdate "$msg_sketch"
+		printf '%s\n' "mcom: cancelled draft $msg_sketch"
 		exit 1
 		;;
 	m|mime)
 		do_mime
-		mshow -t "$draftmime"
+		mshow -t "$draft"
 		c=
 		;;
 	e|edit)
 		c=
-		if ! ${EDITOR:-vi} "$draft"; then
+		if ! ${EDITOR:-vi} "$msg_sketch"; then
 			c=d
 		else
-			if checksensible "$draft"; then
-				stripempty "$draft"
-				if mmime -c <"$draft" && ! needs_multipart "$draft"; then
+			if checksensible "$msg_sketch"; then
+				stripempty "$msg_sketch"
+				if mmime -c <"$msg_sketch" && ! needs_multipart "$msg_sketch"; then
 					automime=
 				else
 					automime=1
@@ -477,8 +477,8 @@ while :; do
 		fi
 		;;
 	justsend)
-		stripempty "$draft"
-		if mmime -c <"$draft" && ! needs_multipart "$draft"; then
+		stripempty "$msg_sketch"
+		if mmime -c <"$msg_sketch" && ! needs_multipart "$msg_sketch"; then
 			automime=
 		else
 			automime=1
@@ -487,29 +487,29 @@ while :; do
 		c=send
 		;;
 	d|delete)
-		rm -i "$draft"
-		if ! [ -f "$draft" ]; then
-			rm -f "$draftmime"
-			printf '%s\n' "mcom: deleted draft $draft"
+		rm -i "$msg_sketch"
+		if ! [ -f "$msg_sketch" ]; then
+			rm -f "$draft"
+			printf '%s\n' "mcom: deleted draft $msg_sketch"
 			exit 0
 		fi
 		c=
 		;;
 	sign)
-		msign "$draft" >"$draftmime"
-		mshow -t "$draftmime"
+		msign "$msg_sketch" >"$draft"
+		mshow -t "$draft"
 		c=
 		;;
 	encrypt)
-		mencrypt "$draft" >"$draftmime"
-		mshow -t "$draftmime"
+		mencrypt "$msg_sketch" >"$draft"
+		mshow -t "$draft"
 		c=
 		;;
 	show)
-		if [ -e "$draftmime" ]; then
-			mshow "$draftmime"
-		else
+		if [ -e "$draft" ]; then
 			mshow "$draft"
+		else
+			mshow "$msg_sketch"
 		fi
 		c=
 		;;

--- a/mcom
+++ b/mcom
@@ -495,16 +495,6 @@ while :; do
 		fi
 		c=
 		;;
-	sign)
-		msign "$msg_sketch" >"$draft"
-		mshow -t "$draft"
-		c=
-		;;
-	encrypt)
-		mencrypt "$msg_sketch" >"$draft"
-		mshow -t "$draft"
-		c=
-		;;
 	show)
 		if [ -e "$draft" ]; then
 			mshow "$draft"
@@ -514,7 +504,7 @@ while :; do
 		c=
 		;;
 	*)
-		printf 'What now? (%s[s]end, [c]ancel, [d]elete, [e]dit, [m]ime, sign, encrypt) ' "${automime:+mime and }"
+		printf 'What now? (%s[s]end, [c]ancel, [d]elete, [e]dit, [m]ime) ' "${automime:+mime and }"
 		read -r c
 		;;
 	esac


### PR DESCRIPTION
First of all: I know I've made quite some big changes in this pull request, but I've put a lot of effort into it and tried my best to not break things. I hope you'll take a look at it. I'm very willing to answer questions or do follow-up work.

The motivation for this pull request is, that `mblaze` did only encrypt messages after a draft had already been created and placed in the outbox (if configured). This means, that a draft could accidentally be synchronized to a remote IMAP server, before it is encrypted. Other mail clients have had the same or similar issues (e.g. [claws mail](http://www.thewildbeast.co.uk/claws-mail/bugzilla/show_bug.cgi?id=2965)).

I've tried to comment my commits comprehensibly. If any of my decisions seem unclear to you, please let me know.

I am aware that there are still things to do:
1. I've not yet updated the man page, because I don't want to have to change it again, after incorporating feedback.
2. Resuming to an encrypted draft is not really possible right now, because there seems to be no easy way to decrypt the message in such a way, that `mencrypt` will be able to encrypt it correctly again. I feel like this is something, that could be figured out later. Maybe something like an `mdecrypt` tool should be written.