### PR TITLE
Add option -0 to mdirs to separate folders by null characters

### DIFF
--- a/man/mdirs.1
+++ b/man/mdirs.1
@@ -27,7 +27,10 @@ By the maildir++ convention, nested maildir folder
 names must begin with
 .Sq Li \&. .
 .Pp
-There are currently no options.
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl 0
+Print folders separated by a null character.
 .Sh EXIT STATUS
 .Ex -std
 .Sh SEE ALSO

--- a/mdirs.c
+++ b/mdirs.c
@@ -9,12 +9,16 @@
 
 #include "blaze822.h"
 
+static int nullflag;
+
 void
 pwd()
 {
 	char cwd[PATH_MAX];
-	if (getcwd(cwd, sizeof cwd))
-		puts(cwd);
+	if (getcwd(cwd, sizeof cwd)) {
+		printf("%s",cwd);
+		putchar( nullflag ? '\0' : '\n');
+	}
 }
 
 void
@@ -72,11 +76,12 @@ int
 main(int argc, char *argv[])
 {
 	int c, i;
-	while ((c = getopt(argc, argv, "")) != -1)
+	while ((c = getopt(argc, argv, "0")) != -1)
 		switch (c) {
+		case '0': nullflag=1; break;
 		default:
 usage:
-			fprintf(stderr, "Usage: mdirs dirs...\n");
+			fprintf(stderr, "Usage: mdirs [-0] dirs...\n");
 			exit(1);
 		}
 


### PR DESCRIPTION
I have some folders with spaces in them. This patch allows me to pipe them to `xargs -0`.